### PR TITLE
build(pip): update required packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-  "setuptools>=42",
-  "wheel",
+  "setuptools>=61",
 ]


### PR DESCRIPTION
bump setuptools from 42 to 61

# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`pyproject.toml` requires `setuptools>=42` and `wheel`, based on PyPA's packaging tutorial.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
`pyproject.toml` now follows the new guidelines for PEP 517 builds (see: https://github.com/pypa/packaging.python.org/pull/1050)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
