### PR TITLE
fix(system): accept String arguments for popup position

### DIFF
--- a/stubs/system/perspective/__init__.pyi
+++ b/stubs/system/perspective/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from com.inductiveautomation.ignition.common.script.adapters import PyJsonObjectAdapter
 from java.lang import String
@@ -73,7 +73,7 @@ def openPopup(
     view: String,
     params: Optional[Dict[String, Any]] = ...,
     title: String = ...,
-    position: Optional[Dict[String, int]] = ...,
+    position: Optional[Dict[String, Union[int, String]]] = ...,
     showCloseIcon: bool = ...,
     draggable: bool = ...,
     resizable: bool = ...,
@@ -113,7 +113,7 @@ def togglePopup(
     view: String,
     params: Optional[Dict[String, Any]],
     title: String = ...,
-    position: Optional[Dict[String, int]] = ...,
+    position: Optional[Dict[String, Union[int, String]]] = ...,
     showCloseIcon: bool = ...,
     draggable: bool = ...,
     resizable: bool = ...,


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`position` argument only accepts `Dict[String, int]`.

E.g. "40%"

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
`position` argument only accepts `Dict[String, Union[int, String]]`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
