### PR TITLE
fix(system): set smtp keyword argument as optional

### DIFF
--- a/stubs/system/net.pyi
+++ b/stubs/system/net.pyi
@@ -43,8 +43,8 @@ def httpPost(url: String, *args: Any, **kwargs: Any) -> String: ...
 def httpPut(url: String, *args: Any, **kwargs: Any) -> String: ...
 def openURL(url: String, useApplet: Optional[bool] = ...) -> None: ...
 def sendEmail(
-    smtp: String,
-    fromAddr: String,
+    smtp: Optional[String] = ...,
+    fromAddr: String = ...,
     subject: Optional[String] = ...,
     body: Optional[String] = ...,
     html: bool = ...,


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`smtp` argument is mandatory.

Issue Number: #42

## What is the new behavior?
<!-- Please describe the new behavior. -->
`smtp` is optional.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Closes: #42