### PR TITLE
build(pip): support installation on 3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-  "setuptools>=61",
+  "setuptools>=59",
 ]
 
 [tool.commitizen]

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ url = https://ignition-api.github.io/stubs
 author = César Román
 author_email = cesar@thecesrom.dev
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
@@ -21,6 +21,11 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Typing :: Stubs Only
     Typing :: Typed
 keywords =
@@ -35,7 +40,7 @@ project_urls =
 
 [options]
 install_requires =
-    mypy[python2]<0.980
+    mypy[python2]==0.971
     types-enum34
 python_requires = >=3.6
 include_package_data = True


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Even though we claim to support Python 3.6, we were not. `setuptools` 59.6.0 was the last version to support 3.6.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
We now allow installing `incendium-stubs` in Python 3.6.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Use `license_files` instead of `license_file` which was deprecated since setuptools v56.0.0