### PR TITLE
ci(github): use tox for running CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         python -m pip install tox-gh
     - name: Setup test suite
       run: |
-        tox r -vv --notest
+        tox4 r -vv --notest
     - name: Run tests
       run: |
-        tox r --vv
+        tox4 r --vv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: ci
 on: [push, pull_request]
 
 jobs:
-  build:
-
+  test:
+    name: test ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,7 +18,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --requirement requirements.txt
-    - name: Analysing the code with mypy
+        python -m pip install tox-gh
+    - name: Setup test suite
       run: |
-        mypy stubs
+        tox r -vv --notest
+    - name: Run tests
+      run: |
+        tox r --vv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tox tox-gh
+        python -m pip install tox-gh
     - name: Setup test suite
       run: |
-        tox r -vv --notest
+        python -m tox r -vv --notest
     - name: Run tests
       run: |
-        tox r --vv
+        python -m tox r --vv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
         python -m tox r -vv --notest
     - name: Run tests
       run: |
-        python -m tox r --vv
+        python -m tox r -vv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tox-gh
+        python -m pip install tox tox-gh
     - name: Setup test suite
       run: |
-        tox4 r -vv --notest
+        tox r -vv --notest
     - name: Run tests
       run: |
-        tox4 r --vv
+        tox r --vv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mypy[python2]<0.980
+mypy[python2]==0.971
 types-enum34

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist = py36,py37,py38,py39,py310,mypy
+skip_missing_interpreters = true
+isolated_build = true
+
+[gh]
+python =
+    3.6 = py36
+    3.7 = py37
+    3.8 = py38
+    3.9 = py39
+    3.10 = py310,mypy
+
+[testenv:mypy]
+skip_install = true
+deps =
+    -rrequirements.txt
+commands =
+    mypy stubs


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We only run `mypy` on Python 3.6-3.10.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
We will use `tox` for running tests on Python 3.6 through 3.10.

On Python 3.6 - 3.9 it will test package installation, and for 3.10 it will install it and run `mypy`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
