### PR TITLE
ci(github): set TOXENV env var based on Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox
+    - name: Pick environment to run
+      run: |
+        import codecs; import os; import sys
+        env = "TOXENV=py{}{}\n".format(*sys.version_info[0:2])
+        print("Picked:\n{}for{}".format(env, sys.version))
+        with codecs.open(os.environ["GITHUB_ENV"], "a", "utf-8") as file_handler:
+              file_handler.write(env)
+      shell: python
     - name: Setup test suite
       run: |
         tox -vv --notest


### PR DESCRIPTION
otherwise we risk running Python 3.8 for every environment for each env in tox envlist

# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Additional to each Python found in `tox`'s `envlist`, our workflow runs Python 3.8.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
We will only run `tox` based on `matrix.python-version`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
