### PR TITLE
revert(ci): use Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  PYTHON_VERSION: '3.11'
+  PYTHON_VERSION: '3.10'
 
 jobs:
   upload:

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
-    py3{11, 10, 9, 8, 7, 6}
+    py3{10, 9, 8, 7, 6}
 isolated_build = true
 skip_missing_interpreters = true
 
-[testenv:py311]
+[testenv:py310]
 description = install and run type check on code base
 commands =
     mypy --config-file tox.ini stubs


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format)
- [x] All applicable pre-commit hooks have passed when running `pre-commit run --all-files`
- [x] All `tox` tests have succeeded

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Revert

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We are using Python 3.11 for tox/CI.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
We will revert back to Python 3.10, as `typed-ast` (a dependency for `mypy[python2]==0.971`) is no longer supported in Python 3.11.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Refs: 03a941e